### PR TITLE
Message in case the method doesn't exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
 					"type": "string",
 					"default": "/app/Controllers",
 					"description": "Root path to the controllers folder"
+				},
+				"adonis_js_goto_controller.showNoMethodMessage": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show a message when no method is found"
 				}
 			}
 		}

--- a/src/link.ts
+++ b/src/link.ts
@@ -1,6 +1,17 @@
 'use strict';
 
-import { workspace, Position, Range, CancellationToken, DocumentLink, DocumentLinkProvider, TextDocument, Uri, ProviderResult, commands } from 'vscode';
+import { 
+  workspace, 
+  Position, 
+  Range, 
+  CancellationToken, 
+  DocumentLink, 
+  DocumentLinkProvider, 
+  TextDocument, 
+  Uri, 
+  ProviderResult, 
+  window 
+} from 'vscode';
 import * as util from './util'
 
 export class LinkProvider implements DocumentLinkProvider {
@@ -52,6 +63,9 @@ export class LinkProvider implements DocumentLinkProvider {
     let path = link.filePath;
     if (lineNum !== -1) {
       path += "#" + lineNum;
+    } else {
+      const showNoMethodMessage = workspace.getConfiguration('adonis_js_goto_controller').showNoMethodMessage;
+      if (showNoMethodMessage) window.showWarningMessage(`The method ${link.funcName} does not exist in the ${link.controllerName}`);
     }
 
     link.target = Uri.parse("file:" + path);


### PR DESCRIPTION
This PR brings a new feature to this extension. When you click in a non-existing method, it will show a warning so you can understand what is going on (Maybe a mistype).

I also implemented an optional checkbox in case the user doesn't want the message to be displayed.

Thank you.